### PR TITLE
Fixed missing brace in ro.json

### DIFF
--- a/ro.json
+++ b/ro.json
@@ -1,4 +1,5 @@
-"info" : {
+{
+	"info" : {
 		"id": "ro",
 		"english_name": "Romanian",
 		"localised_name": "Romana"


### PR DESCRIPTION
The json file needs to contain an object - the top brace was removed, so the translation can't be read properly. This should fix the issue